### PR TITLE
fix 07_handlers test with Postgres 12.2

### DIFF
--- a/expected/07_handlers.out
+++ b/expected/07_handlers.out
@@ -2,10 +2,10 @@
     There may be a race condition in WaitForBackgroundWorkerStartup that 
     leads to indeterminate behavior on a bad launch.
 
-    For this reason, we set log_min_messages to FATAL.  These tests then
+    For this reason, we set log_min_messages to ERROR.  These tests then
     really only ensure that the server lives OK during a bad launch.
 ***/
-SET client_min_messages TO FATAL;
+SET client_min_messages TO ERROR;
 --The _launch function is not supposed to be used directly
 --This tests that stupid things don't do something really bad
 DROP TABLE IF EXISTS bad_pid;

--- a/expected/07_handlers_1.out
+++ b/expected/07_handlers_1.out
@@ -2,10 +2,10 @@
     There may be a race condition in WaitForBackgroundWorkerStartup that 
     leads to indeterminate behavior on a bad launch.
 
-    For this reason, we set log_min_messages to FATAL.  These tests then
+    For this reason, we set log_min_messages to ERROR.  These tests then
     really only ensure that the server lives OK during a bad launch.
 ***/
-SET client_min_messages TO FATAL;
+SET client_min_messages TO ERROR;
 --The _launch function is not supposed to be used directly
 --This tests that stupid things don't do something really bad
 DROP TABLE IF EXISTS bad_pid;

--- a/expected/07_handlers_2.out
+++ b/expected/07_handlers_2.out
@@ -2,10 +2,10 @@
     There may be a race condition in WaitForBackgroundWorkerStartup that 
     leads to indeterminate behavior on a bad launch.
 
-    For this reason, we set log_min_messages to FATAL.  These tests then
+    For this reason, we set log_min_messages to ERROR.  These tests then
     really only ensure that the server lives OK during a bad launch.
 ***/
-SET client_min_messages TO FATAL;
+SET client_min_messages TO ERROR;
 --The _launch function is not supposed to be used directly
 --This tests that stupid things don't do something really bad
 DROP TABLE IF EXISTS bad_pid;

--- a/expected/07_handlers_3.out
+++ b/expected/07_handlers_3.out
@@ -2,10 +2,10 @@
     There may be a race condition in WaitForBackgroundWorkerStartup that 
     leads to indeterminate behavior on a bad launch.
 
-    For this reason, we set log_min_messages to FATAL.  These tests then
+    For this reason, we set log_min_messages to ERROR.  These tests then
     really only ensure that the server lives OK during a bad launch.
 ***/
-SET client_min_messages TO FATAL;
+SET client_min_messages TO ERROR;
 --The _launch function is not supposed to be used directly
 --This tests that stupid things don't do something really bad
 DROP TABLE IF EXISTS bad_pid;

--- a/sql/07_handlers.sql
+++ b/sql/07_handlers.sql
@@ -2,10 +2,10 @@
     There may be a race condition in WaitForBackgroundWorkerStartup that 
     leads to indeterminate behavior on a bad launch.
 
-    For this reason, we set log_min_messages to FATAL.  These tests then
+    For this reason, we set log_min_messages to ERROR.  These tests then
     really only ensure that the server lives OK during a bad launch.
 ***/
-SET client_min_messages TO FATAL;
+SET client_min_messages TO ERROR;
 
 --The _launch function is not supposed to be used directly
 --This tests that stupid things don't do something really bad


### PR DESCRIPTION
The FATAL keyword isn't allowed in client_min_messages since
[postgresql v9](https://www.postgresql.org/docs/9.0/runtime-config-logging.html). 10 and later have that only on log_min_messages, but
no more on client_min_messages [10](https://www.postgresql.org/docs/10/runtime-config-logging.html#RUNTIME-CONFIG-LOGGING-WHEN)[11](https://www.postgresql.org/docs/11/runtime-config-logging.html#RUNTIME-CONFIG-LOGGING-WHEN)[12](https://www.postgresql.org/docs/12/runtime-config-logging.html#RUNTIME-CONFIG-LOGGING-WHEN).

From the failing test:
```
   SET client_min_messages TO FATAL;
  +ERROR:  invalid value for parameter "client_min_messages": "fatal"
  +HINT:  Available values: debug5, debug4, debug3, debug2, debug1, log,
   notice, warning, error
```

Due to that the test fails to hide even simple messages and we get later
on these extra test fails:

```
   DROP TABLE IF EXISTS bad_pid;
  +NOTICE:  table "bad_pid" does not exist, skipping
   ...
   DROP TABLE IF EXISTS bad_pid_2;
  +NOTICE:  table "bad_pid_2" does not exist, skipping
```

By changing FATAL to the still allowed ERROR level this works again.
The level ERROR should be even fine for PG-9 in case one uses the old
versions still.

The test fail can be seen in [Ubuntu](http://autopkgtest.ubuntu.com/packages/p/pglogical-ticker/focal/amd64) and [Debian](https://ci.debian.net/packages/p/pglogical-ticker/)