### PR TITLE
PGDLLEXPORT the module functions

### DIFF
--- a/pglogical_ticker.c
+++ b/pglogical_ticker.c
@@ -34,8 +34,8 @@ PG_MODULE_MAGIC;
 
 PG_FUNCTION_INFO_V1(pglogical_ticker_launch);
 
-void		_PG_init(void);
-void		pglogical_ticker_main(Datum) pg_attribute_noreturn();
+PGDLLEXPORT void		_PG_init(void);
+PGDLLEXPORT void		pglogical_ticker_main(Datum) pg_attribute_noreturn();
 
 /* flags set by signal handlers */
 static volatile sig_atomic_t got_sighup = false;


### PR DESCRIPTION
PG16 got stricter in requiring PGDLLEXPORT on background worker functions.

```
2023-09-19 12:52:50.355 UTC [678337] ERROR:  could not find function "pglogical_ticker_main" in file "/usr/lib/postgresql/16/lib/pglogical_ticker.so"
2023-09-19 12:52:50.357 UTC [678269] LOG:  background worker "pglogical_ticker" (PID 678337) exited with exit code 1
```